### PR TITLE
GitHub Actions: Replace nose with pytest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
     - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
                 --exit-zero --line-length=1100 --target-version=py37 --statistics . | sort -k 2
     - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
-                --format=github --line-length=1100 --target-version=py37
+                --format=github --line-length=1100 --target-version=py37 .
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,14 +10,22 @@ on:
     branches: [ "master", "dev" ]
 
 jobs:
-  build:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
+                --exit-zero --line-length=1100 --target-version=py37 --statistics . | sort -k 2
+    - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
+                --format=github --line-length=1100 --target-version=py37
 
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,7 +34,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        pip install --upgrade pip
+        pip install pytest
+    - run: pip install --editable .
     - name: Test with pytest
       run: pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -27,15 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest numpy scipy networkx mlxtend scikit-learn nose
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    #Lint testing is disabled for now.
-    #- name: Lint with flake8
-    #  run: |
-    #    # stop the build if there are Python syntax errors or undefined names
-    #    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    #    # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-    #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with nosetest
-      run: |
-        nosetests packman -a '!slow'
+        python -m pip install flake8 pytest
+    - name: Test with pytest
+      run: pytest


### PR DESCRIPTION
As demonstrated in #40, The tool nose2pytest finds no tests to convert.

So try testing with pytest...  With output like https://github.com/cclauss/PACKMAN/actions
```
============================= test session starts ==============================
platform linux -- Python 3.9.16, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/runner/work/PACKMAN/PACKMAN
collected 15 items

packman/tests/anm/test_anm.py ..                                         [ 13%]
packman/tests/dci/test_dci.py .                                          [ 20%]
packman/tests/entropy/test_entropy.py .                                  [ 26%]
packman/tests/geometry/test_geometry.py ..                               [ 40%]
packman/tests/gnm/test_gnm.py .                                          [ 46%]
packman/tests/molecule/test_molecule.py ........                         [100%]

=============================== warnings summary ===============================
packman/tests/geometry/test_geometry.py::TestGeometry::test_AlphaShape
  /home/runner/work/PACKMAN/PACKMAN/packman/tests/geometry/test_geometry.py:22: DeprecationWarning: Delaunay attribute 'vertices' is deprecated in favour of 'simplices' and will be removed in Scipy 1.11.0.
    self.assertIsInstance( geometry.AlphaShape( [j for i in self.mol[0].get_backbone() for j in i], 4 )[0][0], molecule.Atom )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 15 passed, 1 warning in 6.09s =========================
```
Added the pytest warning as issue:
* #41 