### PR TITLE
ruff --select=E711,E712 --fix .

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: pip install --user ruff
-    - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
-                --exit-zero --line-length=1100 --target-version=py37 --statistics . | sort -k 2
-    - run: ruff --ignore=E402,E701,E711,E712,E722,E741,F401,F402,F403,F841
+    - run: ruff --exit-zero --line-length=1100 --target-version=py37 --statistics . | sort -k 2
+    - run: ruff --ignore=E402,E701,E722,E741,F401,F403,F841
                 --format=github --line-length=1100 --target-version=py37 .
 
   build:

--- a/additional codes/ScanAlpha.py
+++ b/additional codes/ScanAlpha.py
@@ -114,7 +114,7 @@ def main():
     mol = molecule.load_structure(filename)
 
 
-    if(chain==None):
+    if(chain is None):
         for i in [i.get_id() for i in mol[0].get_chains()]:
             backbone = [k for j in mol[0][i].get_backbone() for k in j if k is not None]
             output=hinge_scanner(backbone,filename,alpha_start,alpha_stop,step_size)

--- a/packman/anm/anm.py
+++ b/packman/anm/anm.py
@@ -60,7 +60,7 @@ class ANM:
         self.pf      = pf
         self.atoms   = [i for i in atoms]
         self.coords  = numpy.array([i.get_location() for i in self.atoms])
-        if self.pf != None and self.pf <= 0:
+        if self.pf is not None and self.pf <= 0:
             raise Exception("pf value cannot be zero or negative")
         if self.gamma <= 0:
             raise Exception("gamma value cannot be zero or negative")
@@ -194,7 +194,7 @@ class ANM:
                     dmat = numpy.array(lobj)
                     distance_mat[i*3:i*3+3, j*3:j*3+3] = dmat
 
-        if self.pf != None:
+        if self.pf is not None:
             hessian = numpy.divide(hessian, distance_mat)
         
         self.hessian=hessian

--- a/packman/anm/hd_anm.py
+++ b/packman/anm/hd_anm.py
@@ -91,7 +91,7 @@ class hdANM:
 
         #Coords are in the same order as the atoms
         self.coords  = numpy.array([i.get_location() for i in atoms])
-        if self.pf != None and self.pf <= 0:
+        if self.pf is not None and self.pf <= 0:
             raise Exception("pf value cannot be zero or negative")
         if self.gamma <= 0:
             raise Exception("gamma value cannot be zero or negative")
@@ -500,7 +500,7 @@ class hdANM:
         """
         x0 = numpy.array([i.get_location() for i in self.atoms])
 
-        if(self.RT_eigen_vectors == None):
+        if(self.RT_eigen_vectors is None):
             self.calculate_RT_eigen_vectors()
         
         exploded_vectors = self.RT_eigen_vectors
@@ -525,7 +525,7 @@ class hdANM:
         """
         
             
-        if(self.RT_eigen_vectors == None):
+        if(self.RT_eigen_vectors is None):
             self.calculate_RT_eigen_vectors()
         EVec=self.get_RT_eigen_vectors().T
         if(n_modes=="all"):

--- a/packman/apps/dci.py
+++ b/packman/apps/dci.py
@@ -46,10 +46,10 @@ class DCI():
 
         if chain:
             self.atoms = [i for i in self.molObj[0][chain].get_calpha()]
-            collect_resi = [i.get_atoms() for i in self.molObj[0][chain].get_residues() if i.get_calpha() != None]
+            collect_resi = [i.get_atoms() for i in self.molObj[0][chain].get_residues() if i.get_calpha() is not None]
         else:
             self.atoms = [i for i in self.molObj[0].get_calpha()]
-            collect_resi = [i.get_atoms() for i in self.molObj[0].get_residues() if i.get_calpha() != None]
+            collect_resi = [i.get_atoms() for i in self.molObj[0].get_residues() if i.get_calpha() is not None]
             
         if n_com:
             if (n_com < 2) or (n_com > len(self.atoms)):

--- a/packman/apps/predict_hinge.py
+++ b/packman/apps/predict_hinge.py
@@ -321,7 +321,7 @@ def predict_hinge(atoms, outputfile, Alpha=float('Inf'),method='alpha_shape',fil
         #If sorting is needed
         DomainNumber, flag = 0, True
         for i in AllChainResidues:
-            if(i.get_domain_id() == None):
+            if(i.get_domain_id() is None):
                 i.set_domain_id('DM'+str(DomainNumber))
                 flag=True
             elif(i.get_domain_id()[:2] == 'FL' and flag):

--- a/packman/bin/GUI.py
+++ b/packman/bin/GUI.py
@@ -331,7 +331,7 @@ class HingePrediction(tk.Frame):
             ALL_RESIDUES = {}
             for i in mol[0].get_chains():
                 try:
-                    ALL_RESIDUES[i.get_id()] = sorted([i.get_id() for i in mol[0][i.get_id()].get_residues() if i!=None])
+                    ALL_RESIDUES[i.get_id()] = sorted([i.get_id() for i in mol[0][i.get_id()].get_residues() if i is not None])
                 except:
                     None
 

--- a/packman/bin/PACKMAN.py
+++ b/packman/bin/PACKMAN.py
@@ -106,7 +106,7 @@ def load_cli():
     """
     args=IO()
 
-    if(args.command==None):
+    if(args.command is None):
         logging.error('Please provide the appropriate input. Enter "python -m packman -h" for more details.')
         exit()
 

--- a/packman/entropy/entropy.py
+++ b/packman/entropy/entropy.py
@@ -33,7 +33,7 @@ class PackingEntropy():
         onspherepoints (int)            : Number of points to be generated around each point for the surface (Read the Publication for more details)
     """
     def __init__(self, atoms, chains=None, probe_size=1.4, onspherepoints=30):
-        if(chains==None):
+        if(chains is None):
             self.atoms = [i for i in atoms]
         else:
             #Single or multiple chain IDs provided. If there are multiple chain ids, they should be in an array form.

--- a/packman/gnm/gnm.py
+++ b/packman/gnm/gnm.py
@@ -177,7 +177,7 @@ class GNM:
         return inverse.diagonal()
         '''
         #Initiate
-        if(endmode==None):
+        if(endmode is None):
             stop_at = len(self.eigen_values)
         else:
             try:

--- a/packman/molecule/chain.py
+++ b/packman/molecule/chain.py
@@ -226,15 +226,15 @@ class Chain():
         the_atom = None
         for i in self.__Residues:
             the_atom =  self.__Residues[i].get_atom(idx)
-            if(the_atom!=None):
+            if(the_atom is not None):
                 break
             
-        if(the_atom==None):
+        if(the_atom is None):
             for i in self.__HetMols:
                 the_atom =  self.__HetMols[i].get_atom(idx)
-                if(the_atom!=None):
+                if(the_atom is not None):
                     break
-        if(the_atom!=None):
+        if(the_atom is not None):
             return the_atom
         else:
             logging.info('The atom with the given ID is not found in the Residues/HetMols')

--- a/packman/molecule/model.py
+++ b/packman/molecule/model.py
@@ -150,15 +150,15 @@ class Model():
         the_atom = None
         for i in self.__AllResidues:
             the_atom =  self.__AllResidues[i].get_atom(idx)
-            if(the_atom!=None):
+            if(the_atom is not None):
                 break
             
-        if(the_atom==None):
+        if(the_atom is None):
             for i in self.__AllHetMols:
                 the_atom =  self.__AllHetMols[i].get_atom(idx)
-                if(the_atom!=None):
+                if(the_atom is not None):
                     break
-        if(the_atom!=None):
+        if(the_atom is not None):
             return the_atom
         else:
             logging.info('The atom with the given ID is not found in this Model')
@@ -311,11 +311,11 @@ class Model():
         
         atom1, atom2 = bond.get_atoms()
 
-        if( neighbor1 == None ):
+        if( neighbor1 is None ):
             logging.error('neighbour1 not selected. Options available for neighbour1: ' +  ', '.join( [str(i) for i in self.__ModelGraph[atom1.get_id()] if i != atom2.get_id() ] ) )
             return None
 
-        if( neighbor2 == None ):
+        if( neighbor2 is None ):
             logging.error('neighbour2 not selected. Options available for neighbour2: ' + ', '.join( [str(i) for i in self.__ModelGraph[atom2.get_id()] if i != atom1.get_id() ]  ) )
             return None
         
@@ -439,11 +439,11 @@ class Model():
         
         atom1, atom2 = bond.get_atoms()
 
-        if( neighbor1 == None ):
+        if( neighbor1 is None ):
             logging.error('neighbour1 not selected. Options available for neighbour1: ' +  ', '.join( [str(i) for i in self.__ModelGraph[atom1.get_id()] if i != atom2.get_id() ] ) )
             return None
 
-        if( neighbor2 == None ):
+        if( neighbor2 is None ):
             logging.error('neighbour2 not selected. Options available for neighbour2: ' + ', '.join( [str(i) for i in self.__ModelGraph[atom2.get_id()] if i != atom1.get_id() ]  ) )
             return None
         
@@ -593,18 +593,18 @@ class Model():
                                         chain1, chain2 = self[temp_dict['_struct_conn.ptnr1_label_asym_id']], self[temp_dict['_struct_conn.ptnr2_label_asym_id']]
                                                                                 
                                         ptnr1 = chain1.get_residue( int(temp_dict['_struct_conn.ptnr1_auth_seq_id']) )
-                                        if(ptnr1==None):
+                                        if(ptnr1 is None):
                                             ptnr1 = chain1.get_hetmol( int(temp_dict['_struct_conn.ptnr1_auth_seq_id']) )
-                                            if(ptnr1==None):
+                                            if(ptnr1 is None):
                                                 ptnr1 = chain1.get_hetmol( temp_dict['_struct_conn.ptnr1_label_comp_id']+temp_dict['_struct_conn.ptnr1_auth_seq_id'] )
 
                                         ptnr2 = chain2.get_residue( int(temp_dict['_struct_conn.ptnr2_auth_seq_id']) )
-                                        if(ptnr2==None):
+                                        if(ptnr2 is None):
                                             ptnr2 = chain2.get_hetmol( int(temp_dict['_struct_conn.ptnr2_auth_seq_id']) )
-                                            if(ptnr2==None):
+                                            if(ptnr2 is None):
                                                 ptnr2 = chain2.get_hetmol( temp_dict['_struct_conn.ptnr2_label_comp_id']+temp_dict['_struct_conn.ptnr2_auth_seq_id'] )
                                         
-                                        if(ptnr1!=None and ptnr2!=None):
+                                        if(ptnr1 is not None and ptnr2 is not None):
                                             atm1 = ptnr1.get_atom(temp_dict['_struct_conn.ptnr1_label_atom_id'])
                                             atm2 = ptnr2.get_atom(temp_dict['_struct_conn.ptnr2_label_atom_id'])
 
@@ -645,7 +645,7 @@ class Model():
                     for j in aa_connectivity[i.get_name()]:
                         try:
                             atom1, atom2 =  i.get_atom(j[0]), i.get_atom(j[1])
-                            if(atom1!=None and atom2!=None and atom1.get_parent().get_parent().get_id() == atom2.get_parent().get_parent().get_id() ):
+                            if(atom1 is not None and atom2 is not None and atom1.get_parent().get_parent().get_id() == atom2.get_parent().get_parent().get_id() ):
                                 counter += 1
                                 if(j[2]=='SING'):
                                     bond = Bond(counter, atom1, atom2, 'covalent-single', source='RCSB/aa-variants-v1.cif')

--- a/packman/molecule/molecule.py
+++ b/packman/molecule/molecule.py
@@ -253,7 +253,7 @@ def load_cif(filename):
 
                             #If particular atom is already present, dont add it again; alternate id must be present (_atom_site.label_alt_id)
                             try:
-                                if( AllResidues[FrameNumber-1][str(ResidueNumber)+ChainID].get_atom(AtomName)!= None ):
+                                if( AllResidues[FrameNumber - 1][str(ResidueNumber) + ChainID].get_atom(AtomName) is not None ):
                                     continue
                             except Exception as e:
                                 #Alternate atom exists
@@ -337,7 +337,7 @@ def load_cif(filename):
 
                             #If particular atom is already present, dont add it again; alternate id must be present (_atom_site.label_alt_id)
                             try:
-                                if( AllHetMols[FrameNumber-1][str(HetMolNumber)+ChainID].get_atom(AtomName)!= None ):
+                                if( AllHetMols[FrameNumber - 1][str(HetMolNumber) + ChainID].get_atom(AtomName) is not None ):
                                     continue
                             except Exception as e:
                                 #Alternate atom exists
@@ -512,7 +512,7 @@ def download_structure(pdbid,save_name=None,ftype='cif'):
     else:
         print('Please provide appropriate "ftype" argument. (cif/pdb).')
 
-    if(save_name==None):
+    if(save_name is None):
         try:
             open(pdbid+'.'+ftype,'wb').write(response.read())
         except(IOError):

--- a/packman/molecule/protein.py
+++ b/packman/molecule/protein.py
@@ -86,12 +86,12 @@ class Protein():
         Returns:
             Protein sequence in FASTA format.
         """
-        for model in self:
+        for model_ in self:
             try:
-                return model.get_sequence()
-            except:
+                return model_.get_sequence()
+            except Exception:
                 None
-            if(all_models==False):
+            if(all_models is False):
                 break
 
     #Set functions
@@ -141,7 +141,7 @@ class Protein():
         #Annotations
         open(filename,'w').write('data_'+filename+'\n#\n')
         fh=open(filename,'a')
-        if(self.__Data != None):
+        if(self.__Data is not None):
             
             #To check what was the input format so that annotation can be written accordingly (currently only supports PDB an mmCIF) | if first line has '#' or '_', it is assumed to be mmCIF file; PDB otherwise.
             input_ftype = None


### PR DESCRIPTION
% `ruff --select=E711,E712 --fix . ` # and manually fixed ruff rule F402

---
% `ruff rule E711`
# none-comparison (E711)

Derived from the **pycodestyle** linter.

Autofix is always available.

## What it does
Checks for comparisons to `None` which are not using the `is` operator.

## Why is this bad?
Per PEP 8, "Comparisons to singletons like None should always be done with
is or is not, never the equality operators."

## Example
```python
if arg != None:
if None == arg:
```

Use instead:
```python
if arg is not None:
```

## References
- [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)
---
% `ruff rule E712`
# true-false-comparison (E712)

Derived from the **pycodestyle** linter.

Autofix is always available.

## What it does
Checks for comparisons to booleans which are not using the `is` operator.

## Why is this bad?
Per PEP 8, "Comparisons to singletons like None should always be done with
is or is not, never the equality operators."

## Example
```python
if arg == True:
if False == arg:
```

Use instead:
```python
if arg is True:
if arg is False:
```

## References
- [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)
---
% `ruff rule F402`
# import-shadowed-by-loop-var (F402)

Derived from the **Pyflakes** linter.

Message formats:
* Import `{name}` from line {line} shadowed by loop variable
---
# What remains to be fixed?
% `ruff --exit-zero --line-length=1100 --target-version=py37 --statistics . | sort -k 2`
```
 12	E402	[ ] Module level import not at top of file
 31	E701	[ ] Multiple statements on one line (colon)
116	E722	[ ] Do not use bare `except`
  2	E741	[ ] Ambiguous variable name: `l`
 55	F401	[*] `packman.molecule` imported but unused
  7	F403	[ ] `from .molecule import *` used; unable to detect undefined names
 13	F841	[*] Local variable `new_coords` is assigned to but never used
```