### PR TITLE
Update geometry.py

### DIFF
--- a/packman/__init__.py
+++ b/packman/__init__.py
@@ -15,4 +15,4 @@ from .utilities import *
 
 
 #VERSION CHANGE HERE CHANGES IT IN docs AND setup.py
-__version__='1.4.7'
+__version__='1.4.8'

--- a/packman/geometry/geometry.py
+++ b/packman/geometry/geometry.py
@@ -97,7 +97,7 @@ def AlphaShape( atoms, alpha, get_graph=False, write_objfile=None ):
     AlphaShape   = []
     ProteinGraph = Graph()
 
-    for a, b, c, d in DelaunayTesssellations.vertices:
+    for a, b, c, d in DelaunayTesssellations.simplices:
         Tetrahydron = [atoms[a],atoms[b],atoms[c],atoms[d]]
         Centre, Radius = Circumsphere(Tetrahydron)
         #Alpha Test

--- a/packman/molecule/model.py
+++ b/packman/molecule/model.py
@@ -90,10 +90,10 @@ class Model():
         self.__properties = {}
 
     def __getitem__(self,ChainID):
-        try:
-            return self.__AllChains[ChainID]
-        except KeyError:
-            logging.warning('Please provide a valid chain ID.')
+        #try:
+        return self.__AllChains[ChainID]
+        #except KeyError:
+        #    logging.warning('Please provide a valid chain ID.')
     
     #Get Functions
     def get_id(self):


### PR DESCRIPTION
.vertices is replaced by .simplices (https://docs.scipy.org/doc/scipy-1.11.0/release/1.11.0-notes.html#expired-deprecations)